### PR TITLE
Remove macos-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.10, 3.11]
 
     steps:


### PR DESCRIPTION
MacOS runners are 10x as expensive as linux ones. We pay for runners while a repo is private. When this is open sourced, we can add back in `macos-latest` to the test matrix.