### PR TITLE
Write out competition subset for 2016 onwards

### DIFF
--- a/cyano/experiment/train_test_split.py
+++ b/cyano/experiment/train_test_split.py
@@ -35,5 +35,16 @@ def make_train_test_competition_split(split_dir="competition"):
         test.to_csv(f, index=True)
 
 
+@app.command()
+def make_train_test_competition_post_2016_split(split_dir="competition_post_2016"):
+    for split in ["train", "test"]:
+        with (SPLITS_PARENT_DIR / "competition" / f"{split}.csv").open("r") as f:
+            df = pd.read_csv(f)
+            df = df[pd.to_datetime(df.date).dt.year >= 2016]
+
+            with (SPLITS_PARENT_DIR / split_dir / f"{split}.csv").open("w") as f:
+                df.to_csv(f, index=False)
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
A little bit of code to subset the competition splits to >= 2016 since that's when we can expect to have sentinel 2 data (you can double check this is the right starting point based on what you've seen).

I think it makes sense to use these data files rather than the competition ones so that we can see in the "number of samples for which there isn't satellite data" just those where it's plausible to expect satellite data.

This does mean we'll need to calculate an updated baseline RMSE for this test set for winning models, which I can do.