### PR TITLE
Check PC search results

### DIFF
--- a/notebooks/klw-pc-checks.ipynb
+++ b/notebooks/klw-pc-checks.ipynb
@@ -7,12 +7,24 @@
    "source": [
     "Issue [19](https://github.com/drivendataorg/cyanobacteria-prediction/issues/19)\n",
     "\n",
-    "Check that our planetary computer results are correct"
+    "Check that our planetary computer results are correct.\n",
+    "\n",
+    "Import code from the cyano package, and check that we get the same selected satelite item metadata (output of `identify_satellite_data`) as we do if we use the past results."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "8b39714d-04fa-4184-be34-5a69bc811e31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext lab_black"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "d222ce72-14fa-4391-bfa2-dda607aa4342",
    "metadata": {},
    "outputs": [],
@@ -28,7 +40,7 @@
     "from cyano.data.satellite_data import (\n",
     "    select_items,\n",
     "    search_planetary_computer,\n",
-    "    get_items_metadata\n",
+    "    get_items_metadata,\n",
     ")"
    ]
   },
@@ -42,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "87b5a37d-9e6c-42cb-a9cd-8d575c73bd95",
    "metadata": {},
    "outputs": [
@@ -52,7 +64,7 @@
        "(6510, 10)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -69,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "3004e64f-5c00-45de-80aa-def466c2eaa8",
    "metadata": {},
    "outputs": [
@@ -177,7 +189,7 @@
        "a7e2d76f204ac347ae5529557eb7f665                195.0    14.833997  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -188,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "88a80e9e-87c4-482e-b945-cbebd543bc34",
    "metadata": {},
    "outputs": [
@@ -203,14 +215,14 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Take a subset to run PC search on\n",
-    "samples = test.sample(n=100, random_state=3) #(n=100, random_state=3)\n",
+    "samples = test.sample(n=100, random_state=3)  # (n=100, random_state=3)\n",
     "samples.region.value_counts()"
    ]
   },
@@ -224,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "178827fa-0497-4258-9f4c-ba206c2160a8",
    "metadata": {},
    "outputs": [
@@ -234,7 +246,7 @@
        "(10000, 15)"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -252,28 +264,29 @@
    "source": [
     "Note that our original PC search includes a time buffer both before *and* after the sample, while our current package code only adds a time buffer *before* the sample. \n",
     "\n",
-    "Rather than comparing the raw results of the PC search, we'll also complete the next step of identifying relevant satellite data (`identify_satellite_data`) to apply the same date range to both, and *then* we'll compare results."
+    "Rather than comparing the raw results of the PC search, we'll also complete the next step of identifying relevant satellite data (`identify_satellite_data`) to get the selected items. This will apply the same date range to both, and *then* we'll compare results."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "87127370-9dec-496a-8f0c-5184cfdcfe92",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def identify_satellite_data_mod(samples: pd.DataFrame,\n",
-    "                           config: FeaturesConfig,\n",
-    "                            candidate_sentinel_meta: pd.DataFrame,\n",
-    "                            sample_item_map: dict\n",
-    "                           ) -> pd.DataFrame:\n",
-    "    \"\"\"Modified version of \n",
+    "def identify_satellite_data_mod(\n",
+    "    samples: pd.DataFrame,\n",
+    "    config: FeaturesConfig,\n",
+    "    candidate_sentinel_meta: pd.DataFrame,\n",
+    "    sample_item_map: dict,\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"Modified version of\n",
     "    cyano.data.utils.satellite_data.identify_satellite_data\n",
     "    that allows us to change the item map and candidate metadata\n",
     "    \"\"\"\n",
     "    selected_meta = []\n",
     "    for sample in tqdm(samples.itertuples(), total=len(samples)):\n",
-    "        sample_item_ids = sample_item_map[sample.Index]['sentinel_item_ids']\n",
+    "        sample_item_ids = sample_item_map[sample.Index][\"sentinel_item_ids\"]\n",
     "        if len(sample_item_ids) == 0:\n",
     "            continue\n",
     "\n",
@@ -285,12 +298,12 @@
     "        sample_items_meta = sample_items_meta[\n",
     "            sample_items_meta.item_id.isin(selected_ids)\n",
     "        ]\n",
-    "        sample_items_meta['sample_id'] = sample.Index\n",
+    "        sample_items_meta[\"sample_id\"] = sample.Index\n",
     "\n",
     "        selected_meta.append(sample_items_meta)\n",
     "\n",
     "    selected_meta = pd.concat(selected_meta).reset_index(drop=True)\n",
-    "    \n",
+    "\n",
     "    return selected_meta"
    ]
   },
@@ -304,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "54f1a485-0a3f-4e0e-acf4-13ef6af17a8d",
    "metadata": {
     "tags": []
@@ -314,7 +327,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████| 100/100 [00:19<00:00,  5.08it/s]"
+      "100%|█████████████████████████████████████████████████████████████████████████████| 100/100 [00:22<00:00,  4.47it/s]"
      ]
     },
     {
@@ -346,29 +359,33 @@
     "        days_search_window=config.pc_days_search_window,\n",
     "        meters_search_window=config.pc_meters_search_window,\n",
     "    )\n",
-    "    \n",
+    "\n",
     "    # Get satellite metadata\n",
     "    sample_items_meta = get_items_metadata(\n",
     "        search_results, sample.latitude, sample.longitude, config\n",
     "    )\n",
-    "    \n",
-    "    regenerated_map[sample.Index]  = {\n",
+    "\n",
+    "    regenerated_map[sample.Index] = {\n",
     "        \"sentinel_item_ids\": sample_items_meta.item_id.tolist()\n",
     "        if len(sample_items_meta) > 0\n",
     "        else []\n",
     "    }\n",
     "    regenerated_candidate_meta.append(sample_items_meta)\n",
-    "    \n",
+    "\n",
     "regenerated_candidate_meta = (\n",
-    "    pd.concat(regenerated_candidate_meta).groupby(\"item_id\", as_index=False)\n",
-    "    .first().reset_index(drop=True)\n",
+    "    pd.concat(regenerated_candidate_meta)\n",
+    "    .groupby(\"item_id\", as_index=False)\n",
+    "    .first()\n",
+    "    .reset_index(drop=True)\n",
     ")\n",
-    "print(f\"Generated metadata for {regenerated_candidate_meta.shape[0]:,} Sentinel item candidates\")"
+    "print(\n",
+    "    f\"Generated metadata for {regenerated_candidate_meta.shape[0]:,} Sentinel item candidates\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "5de86d14-1967-484d-b146-1d8ea74f295c",
    "metadata": {},
    "outputs": [
@@ -376,7 +393,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 266.43it/s]\n"
+      "100%|████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 286.37it/s]\n"
      ]
     },
     {
@@ -385,24 +402,25 @@
        "(332, 27)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# generate metadata for selected items\n",
     "regenerated_meta = identify_satellite_data_mod(\n",
-    "    samples = samples,\n",
-    "    config = config,\n",
-    "    candidate_sentinel_meta = regenerated_candidate_meta,\n",
-    "    sample_item_map = regenerated_map\n",
+    "    samples=samples,\n",
+    "    config=config,\n",
+    "    candidate_sentinel_meta=regenerated_candidate_meta,\n",
+    "    sample_item_map=regenerated_map,\n",
     ")\n",
     "regenerated_meta.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "69a53c09-2f12-4ba8-95c3-58669204f794",
    "metadata": {},
    "outputs": [
@@ -560,7 +578,7 @@
        "[2 rows x 27 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -579,7 +597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "9a9a3bab-614c-4c93-95b0-c72620bd2dd0",
    "metadata": {},
    "outputs": [
@@ -597,13 +615,9 @@
     "    AnyPath(\"s3://drivendata-competition-nasa-cyanobacteria\")\n",
     "    / \"data/interim/full_pc_search\"\n",
     ")\n",
-    "loaded_candidate_meta = pd.read_csv(\n",
-    "    pc_results_dir / \"sentinel_metadata.csv\"\n",
-    ")\n",
+    "loaded_candidate_meta = pd.read_csv(pc_results_dir / \"sentinel_metadata.csv\")\n",
     "assert loaded_candidate_meta.item_id.is_unique\n",
-    "print(\n",
-    "    f\"Loaded {loaded_candidate_meta.shape[0]:,} rows of Sentinel candidate metadata\"\n",
-    ")\n",
+    "print(f\"Loaded {loaded_candidate_meta.shape[0]:,} rows of Sentinel candidate metadata\")\n",
     "\n",
     "with open(pc_results_dir / \"sample_item_map.json\", \"r\") as fp:\n",
     "    loaded_map = json.load(fp)\n",
@@ -612,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "5350ed3c-4f8d-4124-a69c-a3dbeb407b29",
    "metadata": {},
    "outputs": [
@@ -620,7 +634,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 149.75it/s]\n"
+      "100%|████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 154.76it/s]\n"
      ]
     },
     {
@@ -629,24 +643,25 @@
        "(332, 36)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# generate metadata for selected items\n",
     "loaded_meta = identify_satellite_data_mod(\n",
-    "    samples = samples,\n",
+    "    samples=samples,\n",
     "    config=config,\n",
-    "    candidate_sentinel_meta = loaded_candidate_meta,\n",
-    "    sample_item_map = loaded_map\n",
+    "    candidate_sentinel_meta=loaded_candidate_meta,\n",
+    "    sample_item_map=loaded_map,\n",
     ")\n",
     "loaded_meta.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "85d4dcf8-8e17-4724-b411-b8f5bcf8f7fc",
    "metadata": {},
    "outputs": [
@@ -800,7 +815,7 @@
        "[2 rows x 36 columns]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -819,7 +834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "f4ce447b-a86e-490e-a0dd-1fe682145551",
    "metadata": {},
    "outputs": [
@@ -829,7 +844,7 @@
        "((332, 36), (332, 27))"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -840,35 +855,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "50c59995-5625-4fd8-b91a-7c235789d291",
    "metadata": {},
    "outputs": [],
    "source": [
-    "include_cols = ['item_id', 'sample_id', \n",
-    "                'datetime', 'platform', 'min_long', 'max_long', 'min_lat',\n",
-    "       'max_lat', 'eo:cloud_cover', 's2:nodata_pixel_percentage',\n",
-    "       'days_before_sample']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "5aff6e5a-90bd-4374-a6bc-060c6ab9139f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "compare_loaded_meta = (\n",
-    "    loaded_meta.sort_values(by=['sample_id', 'item_id'])[include_cols].round(5)\n",
-    ")\n",
-    "compare_regenerated_meta = (\n",
-    "    regenerated_meta.sort_values(by=['sample_id', 'item_id'])[include_cols].round(5)\n",
-    ")"
+    "include_cols = [\n",
+    "    \"item_id\",\n",
+    "    \"sample_id\",\n",
+    "    \"datetime\",\n",
+    "    \"platform\",\n",
+    "    \"min_long\",\n",
+    "    \"max_long\",\n",
+    "    \"min_lat\",\n",
+    "    \"max_lat\",\n",
+    "    \"eo:cloud_cover\",\n",
+    "    \"s2:nodata_pixel_percentage\",\n",
+    "    \"days_before_sample\",\n",
+    "]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "5aff6e5a-90bd-4374-a6bc-060c6ab9139f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compare_loaded_meta = loaded_meta.sort_values(by=[\"sample_id\", \"item_id\"])[\n",
+    "    include_cols\n",
+    "].round(5)\n",
+    "compare_regenerated_meta = regenerated_meta.sort_values(by=[\"sample_id\", \"item_id\"])[\n",
+    "    include_cols\n",
+    "].round(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "id": "c5179596-f830-4c14-8300-3b3fabe82b3b",
    "metadata": {},
    "outputs": [
@@ -889,7 +913,7 @@
        "dtype: bool"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -901,7 +925,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1080d77d-1995-4598-ab41-2e33396e9b00",
+   "id": "15048391-853d-4403-ae1b-396bd95024e9",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -909,7 +933,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15048391-853d-4403-ae1b-396bd95024e9",
+   "id": "39b6d412-0737-4c0a-b5b8-e066b354a3de",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bba71f95-25f4-4e60-8e05-4efbd8aa7fdc",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/script/klw-pc-checks.py
+++ b/notebooks/script/klw-pc-checks.py
@@ -3,7 +3,12 @@
 
 # Issue [19](https://github.com/drivendataorg/cyanobacteria-prediction/issues/19)
 # 
-# Check that our planetary computer results are correct
+# Check that our planetary computer results are correct.
+# 
+# Import code from the cyano package, and check that we get the same selected satelite item metadata (output of `identify_satellite_data`) as we do if we use the past results.
+
+get_ipython().run_line_magic('load_ext', 'lab_black')
+
 
 import json
 
@@ -16,7 +21,7 @@ from cyano.data.utils import add_unique_identifier
 from cyano.data.satellite_data import (
     select_items,
     search_planetary_computer,
-    get_items_metadata
+    get_items_metadata,
 )
 
 
@@ -35,7 +40,7 @@ test.head(2)
 
 
 # Take a subset to run PC search on
-samples = test.sample(n=100, random_state=3) #(n=100, random_state=3)
+samples = test.sample(n=100, random_state=3)  # (n=100, random_state=3)
 samples.region.value_counts()
 
 
@@ -48,20 +53,21 @@ config.pc_meters_search_window, config.pc_days_search_window
 
 # Note that our original PC search includes a time buffer both before *and* after the sample, while our current package code only adds a time buffer *before* the sample. 
 # 
-# Rather than comparing the raw results of the PC search, we'll also complete the next step of identifying relevant satellite data (`identify_satellite_data`) to apply the same date range to both, and *then* we'll compare results.
+# Rather than comparing the raw results of the PC search, we'll also complete the next step of identifying relevant satellite data (`identify_satellite_data`) to get the selected items. This will apply the same date range to both, and *then* we'll compare results.
 
-def identify_satellite_data_mod(samples: pd.DataFrame,
-                           config: FeaturesConfig,
-                            candidate_sentinel_meta: pd.DataFrame,
-                            sample_item_map: dict
-                           ) -> pd.DataFrame:
-    """Modified version of 
+def identify_satellite_data_mod(
+    samples: pd.DataFrame,
+    config: FeaturesConfig,
+    candidate_sentinel_meta: pd.DataFrame,
+    sample_item_map: dict,
+) -> pd.DataFrame:
+    """Modified version of
     cyano.data.utils.satellite_data.identify_satellite_data
     that allows us to change the item map and candidate metadata
     """
     selected_meta = []
     for sample in tqdm(samples.itertuples(), total=len(samples)):
-        sample_item_ids = sample_item_map[sample.Index]['sentinel_item_ids']
+        sample_item_ids = sample_item_map[sample.Index]["sentinel_item_ids"]
         if len(sample_item_ids) == 0:
             continue
 
@@ -73,12 +79,12 @@ def identify_satellite_data_mod(samples: pd.DataFrame,
         sample_items_meta = sample_items_meta[
             sample_items_meta.item_id.isin(selected_ids)
         ]
-        sample_items_meta['sample_id'] = sample.Index
+        sample_items_meta["sample_id"] = sample.Index
 
         selected_meta.append(sample_items_meta)
 
     selected_meta = pd.concat(selected_meta).reset_index(drop=True)
-    
+
     return selected_meta
 
 
@@ -97,31 +103,36 @@ for sample in tqdm(samples.itertuples(), total=len(samples)):
         days_search_window=config.pc_days_search_window,
         meters_search_window=config.pc_meters_search_window,
     )
-    
+
     # Get satellite metadata
     sample_items_meta = get_items_metadata(
         search_results, sample.latitude, sample.longitude, config
     )
-    
-    regenerated_map[sample.Index]  = {
+
+    regenerated_map[sample.Index] = {
         "sentinel_item_ids": sample_items_meta.item_id.tolist()
         if len(sample_items_meta) > 0
         else []
     }
     regenerated_candidate_meta.append(sample_items_meta)
-    
+
 regenerated_candidate_meta = (
-    pd.concat(regenerated_candidate_meta).groupby("item_id", as_index=False)
-    .first().reset_index(drop=True)
+    pd.concat(regenerated_candidate_meta)
+    .groupby("item_id", as_index=False)
+    .first()
+    .reset_index(drop=True)
 )
-print(f"Generated metadata for {regenerated_candidate_meta.shape[0]:,} Sentinel item candidates")
+print(
+    f"Generated metadata for {regenerated_candidate_meta.shape[0]:,} Sentinel item candidates"
+)
 
 
+# generate metadata for selected items
 regenerated_meta = identify_satellite_data_mod(
-    samples = samples,
-    config = config,
-    candidate_sentinel_meta = regenerated_candidate_meta,
-    sample_item_map = regenerated_map
+    samples=samples,
+    config=config,
+    candidate_sentinel_meta=regenerated_candidate_meta,
+    sample_item_map=regenerated_map,
 )
 regenerated_meta.shape
 
@@ -135,24 +146,21 @@ pc_results_dir = (
     AnyPath("s3://drivendata-competition-nasa-cyanobacteria")
     / "data/interim/full_pc_search"
 )
-loaded_candidate_meta = pd.read_csv(
-    pc_results_dir / "sentinel_metadata.csv"
-)
+loaded_candidate_meta = pd.read_csv(pc_results_dir / "sentinel_metadata.csv")
 assert loaded_candidate_meta.item_id.is_unique
-print(
-    f"Loaded {loaded_candidate_meta.shape[0]:,} rows of Sentinel candidate metadata"
-)
+print(f"Loaded {loaded_candidate_meta.shape[0]:,} rows of Sentinel candidate metadata")
 
 with open(pc_results_dir / "sample_item_map.json", "r") as fp:
     loaded_map = json.load(fp)
 print(f"Loaded sample item map for {len(loaded_map):,} samples")
 
 
+# generate metadata for selected items
 loaded_meta = identify_satellite_data_mod(
-    samples = samples,
+    samples=samples,
     config=config,
-    candidate_sentinel_meta = loaded_candidate_meta,
-    sample_item_map = loaded_map
+    candidate_sentinel_meta=loaded_candidate_meta,
+    sample_item_map=loaded_map,
 )
 loaded_meta.shape
 
@@ -165,21 +173,33 @@ loaded_meta.head(2)
 loaded_meta.shape, regenerated_meta.shape
 
 
-include_cols = ['item_id', 'sample_id', 
-                'datetime', 'platform', 'min_long', 'max_long', 'min_lat',
-       'max_lat', 'eo:cloud_cover', 's2:nodata_pixel_percentage',
-       'days_before_sample']
+include_cols = [
+    "item_id",
+    "sample_id",
+    "datetime",
+    "platform",
+    "min_long",
+    "max_long",
+    "min_lat",
+    "max_lat",
+    "eo:cloud_cover",
+    "s2:nodata_pixel_percentage",
+    "days_before_sample",
+]
 
 
-compare_loaded_meta = (
-    loaded_meta.sort_values(by=['sample_id', 'item_id'])[include_cols].round(5)
-)
-compare_regenerated_meta = (
-    regenerated_meta.sort_values(by=['sample_id', 'item_id'])[include_cols].round(5)
-)
+compare_loaded_meta = loaded_meta.sort_values(by=["sample_id", "item_id"])[
+    include_cols
+].round(5)
+compare_regenerated_meta = regenerated_meta.sort_values(by=["sample_id", "item_id"])[
+    include_cols
+].round(5)
 
 
 (compare_loaded_meta == compare_regenerated_meta).all()
+
+
+
 
 
 


### PR DESCRIPTION
closes #19 

Check that our planetary computer results are correct.

Import code from the cyano package, and check that we get the same selected satelite item metadata (output of `identify_satellite_data`) as we do if we use the past results.

**We likely want to ultimately close this PR without merging** -- we don't need to add `notebooks/klw-pc-checks.ipynb` to the package.