### PR TITLE
Remove functionality to load past PC results

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ loguru
 matplotlib
 numpy
 odc-stac
-pandas==2.0.3
+pandas
 pathlib
 planetary-computer
 pydantic


### PR DESCRIPTION
closes #18 

In `satellite_data.py`, removes the functionality to load past PC search results for all competition data. Also parallelizes the planetary computer search for speed.