### PR TITLE
Revert "Add manifest file"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include cyano/assets/*


### PR DESCRIPTION
Reverts drivendataorg/cyanobacteria-prediction#84

Flit packages data files without special configuration as long as they're included in the package folder.