### PR TITLE
Test implementing a filter for items with >85% no data

### DIFF
--- a/notebooks/0.0-klw-nodata-filter.ipynb
+++ b/notebooks/0.0-klw-nodata-filter.ipynb
@@ -18,7 +18,7 @@
    "source": [
     "### Takeaway (spoiler!)\n",
     "\n",
-    "Overall, I'm very on the fence but I lean towards implementing this.\n",
+    "Overall, I'm pretty on the fence but I lean towards implementing this.\n",
     "\n",
     "- The only samples that are dropped from prediction and training are older samples, so this change is unlikely to affect the number of samples we are able to predict on in the future\n",
     "- The largest difference in performance is better identification of high-severity samples. There is some loss of performance in identifying low-severity samples, but the change is smaller."

--- a/notebooks/script/0.0-klw-nodata-filter.py
+++ b/notebooks/script/0.0-klw-nodata-filter.py
@@ -8,7 +8,7 @@
 
 # ### Takeaway (spoiler!)
 # 
-# Overall, I'm very on the fence but I lean towards implementing this.
+# Overall, I'm pretty on the fence but I lean towards implementing this.
 # 
 # - The only samples that are dropped from prediction and training are older samples, so this change is unlikely to affect the number of samples we are able to predict on in the future
 # - The largest difference in performance is better identification of high-severity samples. There is some loss of performance in identifying low-severity samples, but the change is smaller.


### PR DESCRIPTION
Check if we can improve the model by filtering out items with a high percentage of "no data" pixels. 

Most items have very low no_data percentages. In the training data, only 8.6% of items have >85% no data (~17% have >50% no data, 0.4% have >90% nodata). I tested out filtering items with >85% no data. That experiment is saved to `s3://drivendata-competition-nasa-cyanobacteria/experiments/results/filter_nodata`

I also added metrics for our current best model to `s3://drivendata-competition-nasa-cyanobacteria/predictions/competition_near_water_550m/metrics`

### Key takeaways

- The only samples that are dropped from prediction and training are older samples, so this change is unlikely to affect the number of samples we are able to predict on in the future
- The largest difference in performance is better identification of high-severity samples. There is some loss of performance in identifying low-severity samples, but the change is smaller.
- Our current best model still performs fairly well on samples for which we only have items with >85% no data. This may be because pixels labeled as no data are still useful for prediction. Useful pixels could be mislabeled as no data, or an item could be mostly no data but with useful pixels around our sample point.

Overall, I'm pretty on the fence but I lean towards implementing this.

### Next steps

If we do decide to make this change, we'll need to:
- [ ] update the model asset in `cyano/assets/model_v0.zip`
- [ ] Save updated predictions and metrics for the new best model to `s3://drivendata-competition-nasa-cyanobacteria/predictions`

### Visuals

Performance on samples whose severity prediction changes (~350)

![image](https://github.com/drivendataorg/cyanobacteria-prediction/assets/46792169/444dbb1c-da6a-4f19-b6d8-294ced7b9a3f)

![image](https://github.com/drivendataorg/cyanobacteria-prediction/assets/46792169/2f8bf1f2-7abc-4d7a-b040-4ff4e48e6bb3)

