### PR TITLE
Add support for python -m cyfi execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CyFi changelog
 
+### Unreleased
+
+- Added support for calling the CLI with `python -m cyfi` ([PR #122](https://github.com/drivendataorg/cyfi/pull/122))
+
 ### v1.0.0 - 2023-10-10
 
 CyFi is a command line tool that uses satellite imagery and machine learning to estimate cyanobacteria levels in small, inland water bodies.

--- a/cyfi/__main__.py
+++ b/cyfi/__main__.py
@@ -1,0 +1,3 @@
+from cyfi.cli import app
+
+app(prog_name="python -m cyfi")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pathlib import Path
 from pyproj import Transformer
 from pytest_mock import mocker  # noqa: F401
+import subprocess
 from typer.testing import CliRunner
 
 from cyfi.cli import app
@@ -222,3 +223,14 @@ def test_cli_evaluate(tmp_path, evaluate_data_path):
         "results.json",
     ]:
         assert (eval_dir / file).exists()
+
+
+def test_python_m_execution():
+    result = subprocess.run(
+        ["python", "-m", "cyfi", "--help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout.startswith("Usage: python -m cyfi")


### PR DESCRIPTION
Adds a `__main__.py` file, which allows you to use `python -m cyfi` as an alternative way to access the CLI. 