### PR TITLE
Disable rich formatting in terminal for github acitons

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", 3.11]
+    env:
+      TERM: dumb
 
     steps:
       - uses: actions/checkout@v3

--- a/cyfi/data/features.py
+++ b/cyfi/data/features.py
@@ -3,13 +3,13 @@ import functools
 import tarfile
 from typing import Union
 
-import appdirs
 from cloudpathlib import AnyPath, S3Path
 import cv2
 from loguru import logger
 import numpy as np
 import pandas as pd
 from pathlib import Path
+import platformdirs
 from scipy.stats.mstats import winsorize
 from tqdm.contrib.concurrent import process_map
 import xarray as xr
@@ -199,7 +199,7 @@ def calculate_metadata_features(samples: pd.DataFrame, config: FeaturesConfig) -
 
     # Pull in land cover classification from CDRP
     if "land_cover" in config.sample_meta_features:
-        lc_cache_dir = Path(appdirs.user_cache_dir()) / "cyfi"
+        lc_cache_dir = Path(platformdirs.user_cache_dir()) / "cyfi"
         lc_cache_dir.mkdir(exist_ok=True)
         land_cover_map_filepath = lc_cache_dir / "C3S-LC-L4-LCCS-Map-300m-P1Y-2020-v2.1.1.nc"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "appdirs",
   "build",
   "cloudpathlib[s3]>=0.4.1",
   "geopandas",
@@ -43,6 +42,7 @@ dependencies = [
   "pandas",
   "pathlib",
   "planetary-computer",
+  "platformdirs",
   "plotly",
   "pydantic>=2.0",
   "pystac",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,4 +233,4 @@ def test_python_m_execution():
         universal_newlines=True,
     )
     assert result.returncode == 0
-    assert result.stdout.startswith("Usage: python -m cyfi")
+    assert "Usage: python -m cyfi" in result.stdout


### PR DESCRIPTION
With the latest update of Gradio, Rich is installed. Currently, Typer uses Rich if Rich is installed and does not have a way to override this (though this [unmerged PR](https://github.com/tiangolo/typer/pull/647) adds this functionality).

This PR disables Rich formatting in the terminal for github actions workflows so that ANSI color escape sequences are not printed. This was the cause of recent [failed workflows](https://github.com/drivendataorg/cyfi/actions/runs/6837352059/job/18593255348).

References:
- [environment variables in Rich docs](https://rich.readthedocs.io/en/latest/console.html?highlight=environment%20variables#environment-variables)
- [setting environment variables in github actions](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow)

Closes #128 

Bonus: Fixes https://github.com/drivendataorg/cyfi/issues/127