### PR TITLE
Add conda-forge instructions for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install CyFi with pip:
 pip install cyfi
 ```
 
-Note: if you're on a Mac, you should install from conda-forge instead.
+If you're on a Mac, you should install from conda-forge instead:
 
 ```
 conda install -c conda-forge cyfi -y

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ Install CyFi with pip:
 pip install cyfi
 ```
 
-If you're on a Mac, you should install from conda-forge instead:
+Alternatively, CyFi can be installed with conda:
 
 ```
-conda install -c conda-forge cyfi -y
+conda install -c conda-forge cyfi
 ```
+
+There is a known issue with the pip installation on M1 Macs due to LightGBM. If you encounter this, we recommend installing CyFi with conda.
 
 For detailed instructions for those installing python for the first time, see the [Installation](https://cyfi.drivendata.org/installation/) page.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ CyFi: Cyanobacteria Finder
 ==============================
 
 [![PyPI](https://img.shields.io/pypi/v/cyfi.svg)](https://pypi.org/project/cyfi/)
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/cyfi.svg)](https://anaconda.org/conda-forge/cyfi)
 [![tests](https://github.com/drivendataorg/cyfi/workflows/tests/badge.svg?branch=main)](https://github.com/drivendataorg/cyfi/actions?query=workflow%3Atests+branch%3Amain)
 [![codecov](https://codecov.io/gh/drivendataorg/cyfi/branch/main/graph/badge.svg)](https://codecov.io/gh/drivendataorg/cyfi)
 
@@ -17,6 +18,12 @@ Install CyFi with pip:
 
 ```
 pip install cyfi
+```
+
+Note: if you're on a Mac, you should install from conda-forge instead.
+
+```
+conda install -c conda-forge cyfi -y
 ```
 
 For detailed instructions for those installing python for the first time, see the [Installation](https://cyfi.drivendata.org/installation/) page.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Read more at [cyfi.drivendata.org](https://cyfi.drivendata.org)
 
 ### Install
 
+> [!NOTE]
+> There is a known [issue](https://github.com/drivendataorg/cyfi/issues/114) with the pip installation on M1 Macs due to LightGBM. If you're on a Mac, we recommend installing CyFi with conda, shown in the second option below.
+
 Install CyFi with pip:
 
 ```
@@ -25,8 +28,6 @@ Alternatively, CyFi can be installed with conda:
 ```
 conda install -c conda-forge cyfi
 ```
-
-There is a known issue with the pip installation on M1 Macs due to LightGBM. If you encounter this, we recommend installing CyFi with conda.
 
 For detailed instructions for those installing python for the first time, see the [Installation](https://cyfi.drivendata.org/installation/) page.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,7 +26,7 @@ Install CyFi with pip:
 pip install cyfi
 ```
 
-Note: if you're on a Mac, you should install from conda-forge instead.
+If you're on a Mac, you should install from conda-forge instead:
 
 ```
 conda install -c conda-forge cyfi -y

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,6 +26,12 @@ Install CyFi with pip:
 pip install cyfi
 ```
 
+Note: if you're on a Mac, you should install from conda-forge instead.
+
+```
+conda install -c conda-forge cyfi -y
+```
+
 For detailed instructions for those installing python for the first time, see the [Installation](installation.md) docs.
 
 ### Generate batch predictions

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -26,11 +26,13 @@ Install CyFi with pip:
 pip install cyfi
 ```
 
-If you're on a Mac, you should install from conda-forge instead:
+Alternatively, CyFi can be installed with conda:
 
 ```
-conda install -c conda-forge cyfi -y
+conda install -c conda-forge cyfi
 ```
+
+There is a known issue with the pip installation on M1 Macs due to LightGBM. If you encounter this, we recommend installing CyFi with conda.
 
 For detailed instructions for those installing python for the first time, see the [Installation](installation.md) docs.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -20,6 +20,10 @@
 
 ### Install
 
+!!! note ""
+
+    Note: There is a known [issue](https://github.com/drivendataorg/cyfi/issues/114) with the pip installation on M1 Macs due to LightGBM. If you're on a Mac, we recommend installing CyFi with conda, shown in the second option below.
+
 Install CyFi with pip:
 
 ```
@@ -31,8 +35,6 @@ Alternatively, CyFi can be installed with conda:
 ```
 conda install -c conda-forge cyfi
 ```
-
-There is a known issue with the pip installation on M1 Macs due to LightGBM. If you encounter this, we recommend installing CyFi with conda.
 
 For detailed instructions for those installing python for the first time, see the [Installation](installation.md) docs.
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -64,7 +64,7 @@ Once the Miniconda installation has finished,
 
 1. Open the terminal by typing ⌘+space (to open spotlight search) and then typing "Terminal". Hit enter.
 
-2. Type `conda install -c conda-forge cyfi` and hit enter
+2. Type `conda install -c conda-forge cyfi` and hit enter. When prompted with "Proceed ([y]/n)?", hit enter again.
 
 3. To check that CyFi has been installed, run `pip show cyfi`
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -39,7 +39,7 @@ Once the Miniconda installation has finished,
 ```
 $ pip show cyfi
 Name: cyfi
-Version: 0.1.0
+Version: 1.1.2
 Summary: CyFi is a Python package to estimate cyanobacteria density in small, inland water bodies using Sentinel-2 satellite imagery.
 ```
 
@@ -64,14 +64,14 @@ Once the Miniconda installation has finished,
 
 1. Open the terminal by typing ⌘+space (to open spotlight search) and then typing "Terminal". Hit enter.
 
-2. Type `pip install cyfi` and hit enter
+2. Type `conda install -c conda-forge cyfi` and hit enter
 
 3. To check that CyFi has been installed, run `pip show cyfi`
 
 ```
 $ pip show cyfi
 Name: cyfi
-Version: 0.1.0
+Version: 1.1.2
 Summary: CyFi is a Python package to estimate cyanobacteria density in small, inland water bodies using Sentinel-2 satellite imagery.
 ```
 
@@ -102,6 +102,6 @@ Summary: CyFi is a Python package to estimate cyanobacteria density in small, in
 ```
 $ pip show cyfi
 Name: cyfi
-Version: 0.1.0
+Version: 1.1.2
 Summary: CyFi is a Python package to estimate cyanobacteria density in small, inland water bodies using Sentinel-2 satellite imagery.
 ```

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -64,9 +64,11 @@ Once the Miniconda installation has finished,
 
 1. Open the terminal by typing ⌘+space (to open spotlight search) and then typing "Terminal". Hit enter.
 
-2. Type `conda install -c conda-forge cyfi` and hit enter. When prompted with "Proceed ([y]/n)?", hit enter again.
+2. Type `conda install -c conda-forge cyfi` and hit enter.
 
-3. To check that CyFi has been installed, run `pip show cyfi`
+3. When prompted with "Proceed ([y]/n)?", hit enter again.
+
+4. To check that CyFi has been installed, run `pip show cyfi`
 
 ```
 $ pip show cyfi

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Changelog: "changelog.md"
 
 markdown_extensions:
+  - admonition
   - toc:
       permalink: True
       toc_depth: 3


### PR DESCRIPTION
Due to LightGBM installation issues on mac, we created a conda-forge feedstock of cyfi. Now that that exists, this PR updates the installation instructions for mac users.

Closes #114 