### PR TITLE
Exit when there is no valid imagery for any point

### DIFF
--- a/cyfi/data/features.py
+++ b/cyfi/data/features.py
@@ -284,7 +284,12 @@ def generate_all_features(
     satellite_features = calculate_satellite_features(satellite_meta, config, cache_dir)
 
     ct_with_satellite = satellite_features.index.nunique()
-    if ct_with_satellite < samples.shape[0]:
+    if ct_with_satellite == 0:
+        logger.error(
+            "Relevant satellite data is not available for any of the provided sample points. Please try a different location or date."
+        )
+        exit(1)
+    elif ct_with_satellite < samples.shape[0]:
         logger.warning(
             f"Relevant satellite data is not available for all sample points. Features will only be generated for {ct_with_satellite:,} sample points with valid satellite imagery ({(ct_with_satellite / samples.shape[0]):.0%} of sample points)"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,6 +199,27 @@ def test_cli_predict_point_crs(mocker, local_model_path):  # noqa: F811
     assert "Invalid value for '--crs" in result.stdout
 
 
+def test_graceful_exit_when_no_satellite_data():
+    # use location and date in SF where it was cloudy all month and there is no valid imagery
+    result = runner.invoke(
+        app,
+        [
+            "predict-point",
+            "--date",
+            "2024-01-04",
+            "--lat",
+            "37.753",
+            "--lon",
+            "-122.364",
+        ],
+    )
+    assert result.exit_code == 1
+    assert (
+        "Relevant satellite data is not available for any of the provided sample points. Please try a different location or date"
+        in result.stdout
+    )
+
+
 def test_cli_evaluate(tmp_path, evaluate_data_path):
     df = pd.read_csv(evaluate_data_path)
     df = add_unique_identifier(df)


### PR DESCRIPTION
Ran into an edge case where there is no valid imagery for any point (hit this when testing out a single point in a cloudy month). This PR adds code to log the error and the exit.