### PR TITLE
Fix failing CyFi Explorer test

### DIFF
--- a/cyfi/visualize.py
+++ b/cyfi/visualize.py
@@ -20,8 +20,8 @@ def visualize(
         help="CyFi output directory containing preds.csv and sentinel_metadata.csv from a prior prediction run.",
     ),
     port: int = typer.Option(
-        7860,
-        help="Port to run the CyFi Explorer on.",
+        None,
+        help="Specific port to run the CyFi Explorer on.",
     ),
 ):
     """Launch CyFi Explorer to see Sentinel-2 imagery alongside predictions."""

--- a/cyfi/visualize.py
+++ b/cyfi/visualize.py
@@ -18,7 +18,11 @@ def visualize(
         Path.cwd(),
         exists=True,
         help="CyFi output directory containing preds.csv and sentinel_metadata.csv from a prior prediction run.",
-    )
+    ),
+    port: int = typer.Option(
+        7860,
+        help="Port to run the CyFi Explorer on.",
+    ),
 ):
     """Launch CyFi Explorer to see Sentinel-2 imagery alongside predictions."""
 
@@ -211,4 +215,4 @@ def visualize(
             map = gr.Plot()
             demo.load(make_map, [], map)
 
-    demo.launch()
+    demo.launch(server_port=port)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -265,8 +265,8 @@ def test_python_m_execution():
     assert "Usage: python -m cyfi" in result.stdout
 
 
-def determine_dashboard_url() -> str:
-    """Determine where the CyFi dashboard will be served based on which ports are already in use"""
+def determine_explorer_url() -> str:
+    """Determine where the CyFi Explorer will be served based on which ports are already in use"""
     # Gradio uses 7860 by default, then increments
     for port in range(7860, 7900):  # Don't check indefinite ports
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -280,7 +280,9 @@ def determine_dashboard_url() -> str:
             # If an error is raised, the port is not in use
             return f"http://127.0.0.1:{port}/"
 
-    raise ValueError("No available ports found for the CyFi dashboard, cannot test CyFi explorer.")
+    raise ValueError(
+        "No available ports between 7860 and 7900 found for the CyFi explorer, cannot test CyFi explorer."
+    )
 
 
 def url_is_up(url: str) -> bool:
@@ -300,8 +302,8 @@ def test_cyfi_explorer_launches(tmp_path):
         ASSETS_DIR / "experiment" / "sentinel_metadata_test.csv",
         tmp_path / "sentinel_metadata.csv",
     )
-    # Determine the dashboard's URL based on which ports are already in use
-    dashboard_url = determine_dashboard_url()
+    # Determine the site's URL based on which ports are already in use
+    explorer_url = determine_explorer_url()
 
     proc = subprocess.Popen(
         ["cyfi", "visualize", str(tmp_path)],
@@ -309,15 +311,15 @@ def test_cyfi_explorer_launches(tmp_path):
         stderr=subprocess.PIPE,
         text=True,
     )
-    dashboard_up = url_is_up(dashboard_url)
+    explorer_up = url_is_up(explorer_url)
     elapsed_time = 0
-    # Give max 2 minutes for the dashboard to start up
-    while dashboard_up is False and elapsed_time < 120:
+    # Give max 2 minutes for the explorer to start up
+    while explorer_up is False and elapsed_time < 120:
         time.sleep(10)
         elapsed_time += 10
-        dashboard_up = url_is_up(dashboard_url)
+        explorer_up = url_is_up(explorer_url)
 
-    assert dashboard_up, f"CyFi Explorer took too long to start up at {dashboard_url}."
+    assert explorer_up, f"CyFi Explorer took too long to start up at {explorer_url}."
 
     proc.send_signal(signal.SIGINT)
     stdout, stderr = proc.communicate()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,7 +281,7 @@ def test_cyfi_explorer_launches(tmp_path):
         ASSETS_DIR / "experiment" / "sentinel_metadata_test.csv",
         tmp_path / "sentinel_metadata.csv",
     )
-    use_port = 7865
+    use_port = 17865
     explorer_url = f"http://127.0.0.1:{use_port}/"
 
     proc = subprocess.Popen(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,7 +281,7 @@ def test_cyfi_explorer_launches(tmp_path):
         ASSETS_DIR / "experiment" / "sentinel_metadata_test.csv",
         tmp_path / "sentinel_metadata.csv",
     )
-    use_port = 7860
+    use_port = 7865
     explorer_url = f"http://127.0.0.1:{use_port}/"
 
     proc = subprocess.Popen(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,7 +267,7 @@ def test_python_m_execution():
 def url_is_up(url: str) -> bool:
     """Check if a URL is up by making a GET request."""
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         return response.status_code == 200
 
     except requests.RequestException:


### PR DESCRIPTION
closes #162 

This PR fixes failing test `test_cyfi_explorer_launches`. This test checks that the [CyFi explorer](https://cyfi.drivendata.org/explorer/) launches.

### Why did it fail?

Previously, we hard-coded waiting 10 seconds for the explorer to start up. Then we checked `stdout` and asserted that it included the log messages that appear when the explorer is launched:
```
$ cyfi visualize example_meta
* Running on local URL:  http://127.0.0.1:7860
* To create a public link, set `share=True` in `launch()`.
```
The explorer takes >10 seconds to start up, so the process was always terminated too early. The `stderr` that was produced during the test ended with a `Keyboard Interrupt`, indicating that we were hitting the line `proc.send_signal(signal.SIGINT)` within the test, rather than an error when trying to launch the explorer.

It's unclear what changed that triggered the test to fail, and why the explorer launched faster before.

### Problem

We need to find a way to monitor whether the explorer has launched, and to proceed with interrupting the process (`proc.send_signal(signal.SIGINT)`) and checking `stdout` only after it has launched. 

`cyfi visualize` never terminates (it continues serving the explorer until there is a keyboard interrupt), so we can't use something like [`proc.wait()`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait). 

### Solution

The test now checks whether the explorer URL is up every 10 seconds, and only proceeds with the test once the site is up. If the explorer takes >2 minutes to launch, the test fails

