### PR TITLE
Adjust logs based on imagery download success / failure

### DIFF
--- a/cyfi/data/features.py
+++ b/cyfi/data/features.py
@@ -37,8 +37,8 @@ def calculate_satellite_features(
     Returns:
         pd.DataFrame: Dataframe where the index is sample ID and there is one column
             for each satellite feature. There will only be rows for samples with
-            satellite imagery. Each row is a unique combination of sample ID and
-            item ID
+            satellite imagery. Each row is a unique sample ID, with features from
+            the best available pystac item.
     """
     # Calculate satellite metadata features
     if "month" in config.satellite_meta_features:
@@ -112,6 +112,7 @@ def calculate_satellite_features(
     cols_to_sort_on = ["days_before_sample"] + (
         ["cloud_pct"] if "cloud_pct" in satellite_features.columns else []
     )
+    # Get one row per sample ID
     satellite_features = (
         satellite_features.sort_values(cols_to_sort_on).reset_index().groupby("sample_id").first()
     )
@@ -276,8 +277,8 @@ def generate_all_features(
             visual_href link to the selected Sentinel image for each sample point.
 
             'features' is a dataframe where the index is sample_id and there is one
-            column for each feature. Each row is a unique combination of
-            sample and pystac item. Only samples that have at least one valid
+            column for each feature. Each row is a unique sample.
+            Only samples that have at least one valid
             non-metadata feature are included in the features dataframe
     """
     # Generate satellite features, only includes samples with imagery

--- a/cyfi/data/satellite_data.py
+++ b/cyfi/data/satellite_data.py
@@ -463,12 +463,13 @@ def download_satellite_data(
     )
     n_successes = sum(results)
 
-    if n_successes == len(satellite_meta):
-        logger.success("Downloaded all satellite imagery successfully.")
-    elif n_successes == 0:
+    if n_successes == 0:
         raise ValueError(
             "No satellite imagery was successfully downloaded. Check the per-item debug logs for details."
         )
+
+    if n_successes == len(satellite_meta):
+        logger.success("Downloaded all satellite imagery successfully.")
     else:
         logger.warning(
             f"{len(satellite_meta) - n_successes} item(s) could not be downloaded. "

--- a/cyfi/data/satellite_data.py
+++ b/cyfi/data/satellite_data.py
@@ -417,7 +417,7 @@ def download_row(
 
         # Return error type
         logger.debug(
-            f"{e.__class__.__module__}.{e.__class__.__name__} raised for sample ID {row.sample_id}, Sentinel-2 item ID {row.item_id}:\n{str(e)}"
+            f"{e.__class__.__module__}.{e.__class__.__name__} raised for sample ID {row.sample_id}, Sentinel-2 item ID {row.item_id} - {str(e)}"
         )
         return False
 

--- a/cyfi/data/satellite_data.py
+++ b/cyfi/data/satellite_data.py
@@ -471,7 +471,8 @@ def download_satellite_data(
         )
     else:
         logger.warning(
-            f"{len(satellite_meta) - n_successes} items could not be downloaded. {n_successes} items were downloaded successfully."
+            f"{len(satellite_meta) - n_successes} item(s) could not be downloaded. "
+            f"{n_successes} item(s) were downloaded successfully."
         )
 
     return n_successes

--- a/cyfi/pipeline.py
+++ b/cyfi/pipeline.py
@@ -114,7 +114,6 @@ class CyFiPipeline:
 
         ## Download satellite data
         download_satellite_data(satellite_meta, samples, self.features_config, self.cache_dir)
-        logger.success("Downloaded satellite imagery")
         logger.info(f"Satellite imagery saved to {self.cache_dir}")
 
         ## Generate features

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -93,8 +93,6 @@ def test_download_satellite_data(tmp_path, satellite_meta, train_data, features_
     assert "item(s) could not be downloaded." in captured.out
 
     # Test case when all imagery is downloaded successfully
-    features_config.use_sentinel_bands = ["B02", "B03"]
-    train_data = add_unique_identifier(train_data)
     download_satellite_data(satellite_meta, train_data, features_config, tmp_path)
 
     # Check that logged message includes a success and expected text

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,7 +1,9 @@
 from distutils.util import strtobool
 import os
 from pathlib import Path
+import sys
 
+from loguru import logger
 import numpy as np
 import pytest
 
@@ -65,27 +67,42 @@ def test_generate_candidate_metadata(train_data, features_config):
     assert "visual_href" in candidate_meta.columns
 
 
-def test_download_satellite_data(tmp_path, satellite_meta, train_data, features_config):
-    # Test a case when nothing is downloaded, download_row errors for every item
+def test_download_satellite_data(tmp_path, satellite_meta, train_data, features_config, capsys):
+    features_config.use_sentinel_bands = ["B02", "B03"]
+    train_data = add_unique_identifier(train_data)
+
+    # Test case when nothing is downloaded, and download_row errors for every item
     new_satellite_meta = satellite_meta.copy()
-    for href_col in new_satellite_meta.filter(regex="_href").columns:
-        new_satellite_meta[href_col] = "bad-href"
+    new_satellite_meta["B02_href"] = "bad-href"
     with pytest.raises(
         ValueError,
         match="No satellite imagery was successfully downloaded. Check the per-item debug logs for details.",
     ):
-        download_satellite_data(satellite_meta, train_data, features_config, tmp_path)
+        download_satellite_data(new_satellite_meta, train_data, features_config, tmp_path)
 
-    # Test a case when some items are downloaded, but not all
+    # Log to stdout so we can check the results with capsys
+    logger.add(sys.stdout, level="DEBUG")
+
+    # Test case when some items are downloaded, but not all
     new_satellite_meta = satellite_meta.copy()
-    new_satellite_meta["B01_href"] = "bad-href"
+    new_satellite_meta.loc[0, "B02_href"] = "bad-href"
+    download_satellite_data(new_satellite_meta, train_data, features_config, tmp_path)
+    captured = capsys.readouterr()
+    assert "SUCCESS" not in captured.out
+    assert "WARNING" in captured.out
+    assert "item(s) could not be downloaded." in captured.out
 
-    # Download imagery
+    # Test case when all imagery is downloaded successfully
     features_config.use_sentinel_bands = ["B02", "B03"]
     train_data = add_unique_identifier(train_data)
     download_satellite_data(satellite_meta, train_data, features_config, tmp_path)
 
-    # Sentinel image cache directory exists
+    # Check that logged message includes a success and expected text
+    captured = capsys.readouterr()
+    assert "SUCCESS" in captured.out
+    assert "Downloaded all satellite imagery successfully." in captured.out
+
+    # Check that Sentinel image cache directory exists
     sentinel_dir = tmp_path / f"sentinel_{features_config.image_feature_meter_window}"
     assert sentinel_dir.exists()
     assert len(list(sentinel_dir.rglob("*.npy"))) > 0

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -66,6 +66,20 @@ def test_generate_candidate_metadata(train_data, features_config):
 
 
 def test_download_satellite_data(tmp_path, satellite_meta, train_data, features_config):
+    # Test a case when nothing is downloaded, download_row errors for every item
+    new_satellite_meta = satellite_meta.copy()
+    for href_col in new_satellite_meta.filter(regex="_href").columns:
+        new_satellite_meta[href_col] = "bad-href"
+    with pytest.raises(
+        ValueError,
+        match="No satellite imagery was successfully downloaded. Check the per-item debug logs for details.",
+    ):
+        download_satellite_data(satellite_meta, train_data, features_config, tmp_path)
+
+    # Test a case when some items are downloaded, but not all
+    new_satellite_meta = satellite_meta.copy()
+    new_satellite_meta["B01_href"] = "bad-href"
+
     # Download imagery
     features_config.use_sentinel_bands = ["B02", "B03"]
     train_data = add_unique_identifier(train_data)


### PR DESCRIPTION
closes [#151](https://github.com/drivendataorg/cyfi/issues/151)

After satellite imagery is downloaded, the logs will depend on how many items were successfully downloaded. 
- If all were downloaded, we log `SUCCESS`
- If only some were downloaded, we log a `WARNING` with the number that were not succesfully downloaded
- If none were downloaded, we raise `ValueError`. The per-item debug logs now include the full original error message, in addition to the error type
  - Previously, if no items were downloaded, we would not hit an error until much later. It eventually would raise a misleading `AttributeError: 'DataFrame' object has no attribute 'cloud_pct'`. This happens when errors occur in every iteration of `download_row`, but no error occurs in `download_satellite_data` outside of the parallelized function.

Each of the three cases above is now checked in `test_features.py`.

Changes to functions in `satellite_data.py`:
- `download_row` now returns True if an item was downloaded, otherwise False.
- `download_satellite_data` returns the number of items successfully downloaded