### PR TITLE
Feature/118 larger satellite image

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,62 @@
+---
+name: Bug Report
+about: Report a bug to help us improve CyFi
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+**Thanks for taking the time to report a bug!** Filling out the details below helps us track down and fix the issue faster. Don't worry if you can't fill in every section — just share what you can.
+
+---
+
+## Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+
+
+## Steps to Reproduce
+
+<!-- Walk us through how to trigger the bug. For example: -->
+
+1. Prepare input file with `...`
+2. Run command `cyfi predict ...`
+3. See error
+
+## Expected Behavior
+
+<!-- What did you expect to happen? -->
+
+
+
+## Actual Behavior / Error Message
+
+<!-- What actually happened? If you got an error or traceback, please paste it in the code block below. -->
+
+```
+Paste your full error message or traceback here
+```
+
+## Environment Info
+
+<!-- Please fill in as much as you can. You can get your CyFi version by running `cyfi --version`. -->
+
+- **OS:** (e.g., Windows 11, macOS 14, Ubuntu 22.04)
+- **Python version:** (e.g., 3.10.12 — run `python --version`)
+- **CyFi version:** (run `cyfi --version`)
+- **Installation method:** (pip / conda)
+
+## Sample Input File
+
+<!-- If applicable, please share the input CSV file (or a few rows from it) that triggered the bug. You can drag and drop the file here or paste the contents below. -->
+
+```csv
+Paste sample input data here (if applicable)
+```
+
+## Additional Context
+
+<!-- Any other details that might help — screenshots, links, related issues, or anything else you'd like to share. -->
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ target/
 
 # Experimentation s3 dir
 experiments/
+
+# test points
+sample_points.csv
+.venv/

--- a/cyfi/visualize.py
+++ b/cyfi/visualize.py
@@ -85,7 +85,7 @@ def visualize(
         )
 
         # plot imagery with point on it
-        fig, ax = plt.subplots(frameon=False)
+        fig, ax = plt.subplots(figsize=(8, 8), frameon=False)
         cropped_img_array.plot.imshow(ax=ax)
         ax.plot(sample.longitude, sample.latitude, "ro", markersize=4, markerfacecolor="None")
         ax.axis("equal")
@@ -183,7 +183,7 @@ def visualize(
                     """
                 )
 
-                image = gr.Image(type="pil", label="Sentinel-2 imagery", container=False)
+                image = gr.Image(type="pil", label="Sentinel-2 imagery", container=False, width="100%")
 
             with gr.Column(scale=2):
                 gr.Markdown(


### PR DESCRIPTION
Fixes #118

## Changes
- Set `figsize=(8, 8)` in `plt.subplots` to generate a larger output image
- Set `width="100%"` on `gr.Image` to fill the full column width in the UI

## Testing
Ran `cyfi visualize` locally and confirmed the satellite image now 
fills the full width of the Sentinel-2 Imagery column.