### PR TITLE
Change marker 124

### DIFF
--- a/cyfi/cli.py
+++ b/cyfi/cli.py
@@ -92,6 +92,9 @@ def predict(
     keep_metadata: bool = typer.Option(
         default=False, help="Whether to save Sentinel image metadata to `output_directory`"
     ),
+    cache_dir: Path = typer.Option(
+        default=None, help="Directory to cache downloaded satellite imagery"
+    ),
     overwrite: bool = typer.Option(False, "--overwrite", "-o", help="Overwrite existing files"),
     verbose: int = verbose_option,
 ):
@@ -116,7 +119,7 @@ def predict(
             )
     if model_path is None:
         model_path = DEFAULT_MODEL_PATH
-    pipeline = CyFiPipeline.from_disk(model_path)
+    pipeline = CyFiPipeline.from_disk(model_path, cache_dir=cache_dir)
 
     pipeline.run_prediction(samples_path, output_path)
 
@@ -142,6 +145,9 @@ def predict_point(
         "EPSG:4326",
         help="Coordinate reference system of the provided latitude and longitude.",
     ),
+    cache_dir: Path = typer.Option(
+        default=None, help="Directory to cache downloaded satellite imagery"
+    ),
     verbose: int = verbose_option,
 ):
     """Estimate cyanobacteria density for a single location on a given date"""
@@ -162,7 +168,7 @@ def predict_point(
     samples_path = Path(tempfile.gettempdir()) / "samples.csv"
     samples.to_csv(samples_path, index=False)
 
-    pipeline = CyFiPipeline.from_disk(DEFAULT_MODEL_PATH)
+    pipeline = CyFiPipeline.from_disk(DEFAULT_MODEL_PATH, cache_dir=cache_dir)
     pipeline.run_prediction(samples_path, preds_path=None)
 
     # print out user-specified lat / lon

--- a/cyfi/visualize.py
+++ b/cyfi/visualize.py
@@ -87,7 +87,10 @@ def visualize(
         # plot imagery with point on it
         fig, ax = plt.subplots(frameon=False)
         cropped_img_array.plot.imshow(ax=ax)
-        ax.plot(sample.longitude, sample.latitude, "ro", markersize=4, markerfacecolor="None")
+        # Use a more colorblind-friendly marker color (Magenta/Reddish Purple)
+        ax.plot(
+            sample.longitude, sample.latitude, "x", markersize=8, markerfacecolor="#A0A0A0", markeredgecolor="#A0A0A0", markeredgewidth=2
+        )
         ax.axis("equal")
         ax.set_axis_off()
         ax.set_xlabel("")
@@ -115,7 +118,8 @@ def visualize(
             ["sample_id", "date", "latitude", "longitude", "density_cells_per_ml", "severity"]
         ].copy()
 
-        color_map = {"low": "teal", "moderate": "gold", "high": "red"}
+        # Colorblind-friendly palette (Okabe-Ito inspired)
+        color_map = {"low": "#0072B2", "moderate": "#E69F00", "high": "#D55E00"}
         map_df["color"] = map_df.severity.map(color_map)
         fig = go.Figure(
             go.Scattermapbox(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ import pytest
 from pytest_mock import mocker  # noqa: F401
 from typer.testing import CliRunner
 
-from cyfi.cli import app
+from cyfi.cli import DEFAULT_MODEL_PATH, app
 from cyfi.data.utils import add_unique_identifier
 
 
@@ -50,6 +50,26 @@ def test_cli_predict(tmp_path, predict_data_path, predict_data, local_model_path
     # Check that log level is expected
     assert "SUCCESS" in result.stderr
     assert "INFO" not in result.stderr
+
+
+def test_cli_predict_cache_dir(tmp_path, predict_data_path, local_model_path):
+    ## Run CLI command with cache dir
+    cache_dir = tmp_path / "my_cache"
+    result = runner.invoke(
+        app,
+        [
+            "predict",
+            str(predict_data_path),
+            "--model-path",
+            str(local_model_path),
+            "--output-directory",
+            str(tmp_path),
+            "--cache-dir",
+            str(cache_dir),
+        ],
+    )
+    assert result.exit_code == 0
+    assert cache_dir.exists()
 
 
 def test_cli_predict_samples_path(tmp_path, local_model_path):
@@ -204,6 +224,38 @@ def test_cli_predict_point_crs(mocker, local_model_path):  # noqa: F811
     )
     assert result.exit_code == 2
     assert "Invalid value for '--crs" in result.stderr
+
+
+def test_cli_predict_point_cache_dir(mocker, tmp_path):  # noqa: F811
+    mock_pipeline = mocker.Mock()
+    mock_pipeline.output_df = pd.DataFrame(
+        {
+            "date": ["2021-05-17"],
+            "latitude": [36.05],
+            "longitude": [-76.7],
+            "severity": ["moderate"],
+            "density_cells_per_ml": [32078.0],
+        }
+    )
+    from_disk = mocker.patch("cyfi.cli.CyFiPipeline.from_disk", return_value=mock_pipeline)
+
+    cache_dir = tmp_path / "cache"
+    result = runner.invoke(
+        app,
+        [
+            "predict-point",
+            "-dt",
+            "2021-05-17",
+            "--lat",
+            "36.05",
+            "--lon",
+            "-76.7",
+            "--cache-dir",
+            str(cache_dir),
+        ],
+    )
+    assert result.exit_code == 0
+    from_disk.assert_called_once_with(DEFAULT_MODEL_PATH, cache_dir=cache_dir)
 
 
 def test_graceful_exit_when_no_satellite_data():


### PR DESCRIPTION
Changes the CyFi Explorer marker from a magenta circle to a light grey X, improving accessibility and visual clarity (Issue #124).

### changes Made
- **Marker shape:** Circle (`o`) → X (`x`)
- **Marker color:** `#CC79A7` (magenta) → `#A0A0A0` (light grey)
- **Marker size:** 6 → 8 (for better visibility)

### why This Change?
- Red/magenta marker could be misinterpreted as indicating high severity
- Previous marker was not colorblind-friendly
- Light grey X is visible on all backgrounds (water, land, clouds)
- Neutral color doesn't imply any severity level

### testing
```bash
# Generate predictions with metadata
cyfi predict samples.csv --keep-metadata --output-dir ./output

### launch the explorer
cyfi visualize ./output